### PR TITLE
Fix cuDF GPU fallback by setting functionNamePrefix before registerCudf()

### DIFF
--- a/velox/experimental/cudf/benchmarks/CudfTpcdsBenchmark.cpp
+++ b/velox/experimental/cudf/benchmarks/CudfTpcdsBenchmark.cpp
@@ -77,6 +77,11 @@ void CudfTpcdsBenchmark::initQueryBuilder() {
 }
 
 void CudfTpcdsBenchmark::initialize() {
+  // Must be set before TpcdsBenchmark::initialize(), which calls
+  // initQueryBuilder() -> registerCudf(), which bakes the prefix into the
+  // step-aware aggregation registry.
+  cudf_velox::CudfConfig::getInstance().functionNamePrefix = "presto.default.";
+
   TpcdsBenchmark::initialize();
 
   if (FLAGS_velox_cudf_table_scan) {


### PR DESCRIPTION
Set CudfConfig::functionNamePrefix = "presto.default." in CudfTpcdsBenchmark::initialize() before calling the base class. Without this, registerCudf() bakes an empty prefix into the step-aware aggregation registry, causing GPU operators to silently fall back to CPU when plan expressions use prefixed names like "presto.default.gte".